### PR TITLE
Modificaitons to the overview

### DIFF
--- a/agent_overview.rst
+++ b/agent_overview.rst
@@ -7,20 +7,16 @@
 Overview
 --------
 
-   The Dell Cloud Manager python agent is a lightweight application written in python that communicates with the Dell Cloud Manager provisioning server and provides enhanced automation and management capabilities.
-   The python agent is only supported on Linux virtual machines. When it is installed on a Linux virtual machine that is launched from Dell Cloud manager it provides functions such as:
+   The Dell Cloud Manager Agent (dcm-agent) is a lightweight application that runs inside of your Linux VM and expands the capabilities of the Dell Cloud Manager (DCM) to provide functions such as:
 
    * Server health monitoring
-   * Automated software installation/configuration
-   * Data set installations
+   * Automated software installation/configuration (puppet and chef are supported)
+   * User management
    * Backups
    * Disk volume management
 
-   The Dell Cloud Manager python agent also contains a set of associated Bash scripts that are responsible for executing some actions on the server and are extensible by end users.
+   The dcm-agent is intended to replace the `legacy agent <http://www.enstratius.com/support/documentation/the-enstratus-application/document-agent/Agent-Overview>`_ for servers that are running Linux.  Windows servers should use the legacy agent.
 
-   All communication between the python agent and the Dell Cloud Manager provisioning server is initiated from the python agent and is is encrypted using SSL. 
-   The python agent opens a socket connection to port 443 on the Dell Cloud Manager provisioning server and can then receive commands to be executed on the virtual machine and can respond back to the Dell Cloud Manager server using the same connection. No inbound ports on the Linux virtual machine running the python agent need to be opened.  The python agent will continuously attempt to reconnect the connection to the Dell Cloud Manager server if the connection is lost.
+   The communication channel between the dcm-agent and the DCM is encrypted using SSL. The dcm-agent opens a websocket connection to port 443. That connection is then used to send commands to the dcm-agent and receive replies from it. No inbound ports on the Linux virtual machine running the dcm-agent need to be opened.
 
-   Every command executed by the python agent comes with a globally unique identifier. This identifier is used to ensure that the agent only executes a received command one time. The commands and identifiers are kept in a SQLite database file. Because of this the agent system can survive reboots.
-
-   The Dell Cloud Manager python agent is supported on many popular GNU/Linux distributions such as Ubuntu, Debian, Cent OS, RHEL and Fedora. 
+   The dcm-agent is supported on many popular GNU/Linux distributions such as Ubuntu, Debian, Cent OS, RHEL and Fedora.


### PR DESCRIPTION
I think we should leave off details about things like idempotency from
the overview and focus on just laying the ground work for what it is.
Such things can be discussed in more advanced sections.

Also we decided to refer to the new agent as dcm-agent (and not rely
on the implmentation detail of the language it is written in for
description).  Also the Java agent is referred to as the legacy agent.